### PR TITLE
Stat tracking per Game and Overall

### DIFF
--- a/Match.cpp
+++ b/Match.cpp
@@ -100,7 +100,7 @@ void Match::sim()
     }
 
     cout << "Score: " << score[0] << "-" << score[1] << endl;
-
+    orderOfPlay[0]->updateOverAllStats();
     shotMap.printHeatMap();
 }
 

--- a/Player.cpp
+++ b/Player.cpp
@@ -256,7 +256,7 @@ void Player::updateEnergy(bool playing)
     if(playing)
     {
         energy -= (2 + (20 - stamina)/2);
-        playerStats.addMinute();
+        playerStatsGame.addMinute();
     }
     else
     {
@@ -458,7 +458,25 @@ int Player::getDefence()
 
 StatList* Player::getStatList()
 {
-    return &playerStats;
+    return &playerStatsGame;
+}
+
+StatList* Player::getOverAllStatList()
+{
+    return &playerStatsOverAll;
+}
+
+void Player::updateOverAllStats()
+{
+    playerStatsOverAll = playerStatsOverAll + playerStatsGame;
+
+    int i = 0;
+}
+
+void Player::resetGameStats()
+{
+    playerStatsGame.resetStats();
+    playerStatsGame.addGame();
 }
 
 //======================================

--- a/Player.h
+++ b/Player.h
@@ -62,13 +62,17 @@ public:
 
 
     StatList* getStatList();
+    StatList* getOverAllStatList();
+    void updateOverAllStats();
+    void resetGameStats();
 
     Heatmap moveTrackerMap;
 private:
     Heatmap posValueMap, finalMap ;
     PlayerPosition *position;
     PlayerStrategy *strategy;
-    StatList playerStats;
+    StatList playerStatsGame, playerStatsOverAll;
+
 
     int posX, posY;
     int number;

--- a/StatList.cpp
+++ b/StatList.cpp
@@ -2,8 +2,38 @@
 
 StatList::StatList()
 {
+    resetStats();
+}
+
+StatList::StatList(std::vector<int> stats)
+{
+    points=stats[0];
+    games=stats[1];
+
+    shots = stats[2];
+    scores = stats[3];
+    threeScores = stats[5];
+    threeShots = stats[4];
+
+
+    offensiveRebounds=stats[6];
+    defensiveRebounds=stats[7];
+
+    assists = stats[8];
+
+    freeThrows = stats[9];
+    freeThrowsScored = stats[10];
+
+    minutes = stats[11];
+
+    blocks = stats[12];
+    steals = stats[13];
+}
+
+void StatList::resetStats()
+{
     points=0;
-    games=1;
+    games=0;
 
     shots = 0;
     scores = 0;
@@ -25,6 +55,47 @@ StatList::StatList()
     steals = 0;
 }
 
+void StatList::writeToFile(std::string filename, int pos)
+{
+    std::ofstream outfile;
+
+      outfile.open(filename, std::ios_base::app);
+      outfile << "pos," << pos << ",points," << points << ",fga," << getShots() << ",fgpc," << getShootingPercentage() ;
+      outfile << ",3pa," << getThreeShots() <<  ",3ppc," << getThreeShootingPercentage();
+      outfile << ",trb," << getRebounds() << ",drb," << defensiveRebounds << ",orb," << offensiveRebounds;
+      outfile << ",fta," << freeThrows << ",ftpc," << getFreeThrowPercentage();
+      outfile << ",stl," << steals << ",blk," << blocks;
+      outfile << ",ast," << getAssists() << ",mp," << minutes << "\n";
+}
+
+StatList StatList::operator+(const StatList &list)
+{
+    std::vector<int> stats;
+
+    stats.push_back(points + list.points);
+    stats.push_back(games + list.games);
+    stats.push_back(shots + list.shots);
+    stats.push_back(scores + list.scores);
+    stats.push_back(threeShots + list.threeShots);
+    stats.push_back(threeScores + list.threeScores);
+    stats.push_back(offensiveRebounds + list.offensiveRebounds);
+    stats.push_back(defensiveRebounds + list.defensiveRebounds);
+    stats.push_back(assists + list.assists);
+    stats.push_back(freeThrows + list.freeThrows);
+    stats.push_back(freeThrowsScored + list.freeThrowsScored);
+    stats.push_back(minutes + list.minutes);
+    stats.push_back(blocks + list.blocks);
+    stats.push_back(steals + list.steals);
+
+    StatList newStatList(stats);
+
+    return newStatList;
+}
+
+//==========================
+// Time
+//==========================
+
 void StatList::addGame()
 {
     games++;
@@ -38,19 +109,6 @@ void StatList::addMinute()
 int StatList::getMinutes()
 {
     return minutes;
-}
-
-void StatList::writeToFile(std::string filename, int pos)
-{
-    std::ofstream outfile;
-
-      outfile.open(filename, std::ios_base::app);
-      outfile << "pos," << pos << ",points," << points << ",fga," << getShots() << ",fgpc," << getShootingPercentage() ;
-      outfile << ",3pa," << getThreeShots() <<  ",3ppc," << getThreeShootingPercentage();
-      outfile << ",trb," << getRebounds() << ",drb," << defensiveRebounds << ",orb," << offensiveRebounds;
-      outfile << ",fta," << freeThrows << ",ftpc," << getFreeThrowPercentage();
-      outfile << ",stl," << steals << ",blk," << blocks;
-      outfile << ",ast," << getAssists() << ",mp," << minutes << "\n";
 }
 
 //==========================

--- a/StatList.cpp
+++ b/StatList.cpp
@@ -111,6 +111,11 @@ int StatList::getMinutes()
     return minutes;
 }
 
+float StatList::getMinutesPerGame()
+{
+    return minutes/games;
+}
+
 //==========================
 // Points
 //==========================
@@ -155,6 +160,11 @@ void StatList::addThreeScore()
     addScore();
 }
 
+int StatList::getPoints()
+{
+    return points;
+}
+
 float StatList::getPointsPerGame()
 {
     return float(points)/float(games);
@@ -165,9 +175,19 @@ int StatList::getShots()
     return shots;
 }
 
+float StatList::getShotsPerGame()
+{
+    return shots/games;
+}
+
 int StatList::getThreeShots()
 {
     return threeShots;
+}
+
+float StatList::getThreeShotsPerGame()
+{
+    return threeShots/games;
 }
 
 float StatList::getShootingPercentage()
@@ -205,6 +225,31 @@ int StatList::getRebounds()
     return defensiveRebounds + offensiveRebounds;
 }
 
+float StatList::getReboundsPerGame()
+{
+    return getRebounds()/games;
+}
+
+int StatList::getOffensiveRebounds()
+{
+    return offensiveRebounds;
+}
+
+float StatList::getOffensiveReboundsPerGame()
+{
+    return offensiveRebounds/games;
+}
+
+int StatList::getDefensiveRebounds()
+{
+    return defensiveRebounds;
+}
+
+float StatList::getDefensiveReboundsPerGame()
+{
+    return defensiveRebounds/games;
+}
+
 void StatList::printReboundingStats()
 {
     std::cout << "Rebounds: " << getRebounds() << " OR: " << offensiveRebounds << " DR: " << defensiveRebounds << std::endl;
@@ -222,6 +267,11 @@ void StatList::addAssist()
 int StatList::getAssists()
 {
     return assists;
+}
+
+float StatList::getAssistsPerGame()
+{
+    return assists/games;
 }
 
 void StatList::printAssistStats()
@@ -268,7 +318,17 @@ int StatList::getBlocks()
     return blocks;
 }
 
+float StatList::getBlocksPerGame()
+{
+    return blocks/games;
+}
+
 int StatList::getSteals()
 {
     return steals;
+}
+
+float StatList::getStealsPerGame()
+{
+    return steals/games;
 }

--- a/StatList.h
+++ b/StatList.h
@@ -14,6 +14,7 @@ public:
     void addGame();
     void addMinute();
     int getMinutes();
+    float getMinutesPerGame();
     void writeToFile(std::string filename, int pos);
 
     void addPoint();
@@ -23,19 +24,28 @@ public:
     void addMiss();
     void addScore();
     void addThreeScore();
+    int getPoints();
     float getPointsPerGame();
     int getShots();
+    float getShotsPerGame();
     float getShootingPercentage();
     int getThreeShots();
+    float getThreeShotsPerGame();
     float getThreeShootingPercentage();
     void printShootingStats();
 
     int getRebounds();
+    float getReboundsPerGame();
+    int getOffensiveRebounds();
+    float getOffensiveReboundsPerGame();
+    int getDefensiveRebounds();
+    float getDefensiveReboundsPerGame();
     void addOffensiveRebound();
     void addDefensiveRebound();
     void printReboundingStats();
 
     int getAssists();
+    float getAssistsPerGame();
     void addAssist();
     void printAssistStats();
 
@@ -46,7 +56,9 @@ public:
     void addBlock();
     void addSteal();
     int getBlocks();
+    float getBlocksPerGame();
     int getSteals();
+    float getStealsPerGame();
 
     StatList operator+(const StatList &list);
 

--- a/StatList.h
+++ b/StatList.h
@@ -1,12 +1,16 @@
 #ifndef STATLIST_H
 #define STATLIST_H
 
+#include <vector>
 #include <iostream>
 #include <fstream>
 class StatList
 {
 public:
     StatList();
+    StatList(std::vector<int> stats);
+
+    void resetStats();
     void addGame();
     void addMinute();
     int getMinutes();
@@ -43,6 +47,8 @@ public:
     void addSteal();
     int getBlocks();
     int getSteals();
+
+    StatList operator+(const StatList &list);
 
 private:
     int points, games, minutes;

--- a/Team.cpp
+++ b/Team.cpp
@@ -279,6 +279,11 @@ void Team::setUpFreeThrowDefence()
 
 void Team::setUpStartGame()
 {
+    for(auto &player: players)
+    {
+        player.second->resetGameStats();
+    }
+
     if(team == 1)
     {
         getPlayer(1)->setPos(-3, 3);

--- a/main.cpp
+++ b/main.cpp
@@ -13,8 +13,8 @@ int main()
         Match m;
 
         m.sim();
-        string filename = string("../stats/Game") + string(to_string(i)) + string(".csv");
-        m.writeMatchStats(filename);
+        //string filename = string("../stats/Game") + string(to_string(i)) + string(".csv");
+        //m.writeMatchStats(filename);
     }
 
     /*


### PR DESCRIPTION
Players maintain two statlists. One is used for games and the other is used for overall stats. The game gets added to the overall after a match.

Added per game methods to better use the overall stats.